### PR TITLE
Assimp shouldn't be a default module

### DIFF
--- a/Tools/projectGenerator/libs/Torque3D.conf
+++ b/Tools/projectGenerator/libs/Torque3D.conf
@@ -33,7 +33,6 @@ includeLib( 'squish' );
 includeLib( 'collada_dom' );
 includeLib( 'pcre' ); 
 includeLib( 'convexDecomp' );
-includeLib( 'assimp' );  
 
 // Use FMOD on consoles
 if ( Generator::$platform != "360" && Generator::$platform != "ps3" )


### PR DESCRIPTION
I assume this was left in for ease of testing...

Protip. When trying to do inter-fork pull requests on branches like this one, change the URL of the page from something like this:

```
https://github.com/eightyeight/Torque3D/compare/assimp
```

To this:

```
https://github.com/eightyeight/Torque3D/compare/assimp...assimp
```

This will mean no diff shows up to slow your page down monstrously, and you can edit the target to PR against the branch you actually _meant_ to target, thank you very much GitHub for assuming you knew what I wanted.
