### PR TITLE
Skybox render order. 3rd times the charm.

### DIFF
--- a/Engine/source/lighting/advanced/hlsl/deferredShadingFeaturesHLSL.cpp
+++ b/Engine/source/lighting/advanced/hlsl/deferredShadingFeaturesHLSL.cpp
@@ -220,3 +220,16 @@ void DeferredSpecPowerHLSL::processPix( Vector<ShaderComponent*> &componentList,
 
    output = new GenOp( "   @.a = 1.0 - @;\r\n", color, specPower );
 }
+
+//****************************************************************************
+// Vertex position
+//****************************************************************************
+void DeferredSkyHLSL::processVert( Vector<ShaderComponent*> &componentList, 
+                                    const MaterialFeatureData &fd )
+{
+   Var *outPosition = (Var*)LangElement::find( "hpos" );
+   MultiLine *meta = new MultiLine;
+   meta->addStatement( new GenOp( "   @.w = @.z;\r\n", outPosition, outPosition ) );
+
+   output = meta;
+}

--- a/Engine/source/lighting/advanced/hlsl/deferredShadingFeaturesHLSL.h
+++ b/Engine/source/lighting/advanced/hlsl/deferredShadingFeaturesHLSL.h
@@ -126,4 +126,11 @@ public:
    virtual U32 getOutputTargets( const MaterialFeatureData &fd ) const { return ShaderFeature::RenderTarget1; }
 };
 
+class DeferredSkyHLSL : public ShaderFeatureHLSL
+{
+public:
+   virtual String getName() { return "Deferred Shading: Sky"; }
+   virtual void processVert( Vector<ShaderComponent*> &componentList,
+                             const MaterialFeatureData &fd );
+};
 #endif

--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -194,6 +194,8 @@ Material::Material()
    
    mDirectSoundOcclusion = 1.f;
    mReverbSoundOcclusion = 1.0;
+
+   mIsSky = false;
 }
 
 void Material::initPersistFields()
@@ -385,6 +387,9 @@ void Material::initPersistFields()
 
    addField("dynamicCubemap", TypeBool, Offset(mDynamicCubemap, Material),
       "Enables the material to use the dynamic cubemap from the ShapeBase object its applied to." );
+
+   addField("isSky", TypeBool, Offset(mIsSky, Material),
+       "Sky support. Alters draw dimensions." );
 
    addGroup( "Behavioral" );
 

--- a/Engine/source/materials/materialDefinition.h
+++ b/Engine/source/materials/materialDefinition.h
@@ -284,6 +284,7 @@ public:
    String mCubemapName;
    CubemapData* mCubemapData;
    bool mDynamicCubemap;
+   bool mIsSky;
 
    bool mTranslucent;   
    BlendOp mTranslucentBlendOp;

--- a/Engine/source/materials/materialFeatureTypes.cpp
+++ b/Engine/source/materials/materialFeatureTypes.cpp
@@ -94,3 +94,4 @@ ImplementFeatureType( MFT_DeferredSpecMap, MFG_Texture, 2.0f, false );
 ImplementFeatureType( MFT_DeferredSpecColor, MFG_Texture, 2.1f, false );
 ImplementFeatureType( MFT_DeferredSpecPower, MFG_Texture, 2.1f, false );
 ImplementFeatureType( MFT_DeferredSpecStrength, MFG_Texture, 2.1f, false );
+ImplementFeatureType( MFT_SkyBox, MFG_Transform, 1.0f, true );

--- a/Engine/source/materials/materialFeatureTypes.h
+++ b/Engine/source/materials/materialFeatureTypes.h
@@ -178,5 +178,5 @@ DeclareFeatureType( MFT_DeferredSpecColor );
 DeclareFeatureType( MFT_DeferredSpecPower );
 DeclareFeatureType( MFT_DeferredSpecStrength );
 DeclareFeatureType( MFT_DeferredEmptySpec );
-
+DeclareFeatureType( MFT_SkyBox );
 #endif // _MATERIALFEATURETYPES_H_

--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -351,6 +351,9 @@ void ProcessedShaderMaterial::_determineFeatures(  U32 stageNum,
                mMaterial->mDynamicCubemap ) )
    fd.features.addFeature( MFT_CubeMap );
 
+   if (mMaterial->mIsSky)
+       fd.features.addFeature( MFT_SkyBox );
+
    fd.features.addFeature( MFT_Visibility );
 
    if (  lastStage && 

--- a/Engine/source/shaderGen/HLSL/shaderGenHLSLInit.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderGenHLSLInit.cpp
@@ -104,6 +104,7 @@ void _initShaderGenHLSL( ShaderGen *shaderGen )
    FEATUREMGR->registerFeature( MFT_DeferredSpecPower, new DeferredSpecPowerHLSL );
    FEATUREMGR->registerFeature( MFT_DeferredSpecStrength, new DeferredSpecStrengthHLSL );
    FEATUREMGR->registerFeature( MFT_DeferredEmptySpec, new DeferredEmptySpecHLSL );
+   FEATUREMGR->registerFeature( MFT_SkyBox, new DeferredSkyHLSL );
 }
 
 MODULE_BEGIN( ShaderGenHLSL )

--- a/My Projects/testDS/game/art/skies/Desert_Sky/materials.cs
+++ b/My Projects/testDS/game/art/skies/Desert_Sky/materials.cs
@@ -34,4 +34,5 @@ singleton Material( DesertSkyMat )
 {
    cubemap = DesertSkyCubemap;
    materialTag0 = "Skies";
+   isSky = true;
 };

--- a/My Projects/testDS/game/art/skies/night/materials.cs
+++ b/My Projects/testDS/game/art/skies/night/materials.cs
@@ -34,6 +34,7 @@ singleton Material( NightSkyMat )
 {
    cubemap = NightCubemap;
    materialTag0 = "Skies";
+   isSky = true;
 };
 
 singleton Material( Moon_Glow_Mat )
@@ -50,4 +51,5 @@ singleton Material( Moon_Mat )
    emissive = true;
    translucent = true;
    vertColor[ 0 ] = true;
+   isSky = true;
 };

--- a/My Projects/testDS/game/core/art/skies/blank/materials.cs
+++ b/My Projects/testDS/game/core/art/skies/blank/materials.cs
@@ -34,6 +34,7 @@ singleton Material( BlackSkyMat )
 {
    cubemap = BlackSkyCubemap;
    materialTag0 = "Skies";
+   isSky = true;
 };
 
 singleton CubemapData( BlueSkyCubemap )
@@ -50,6 +51,7 @@ singleton Material( BlueSkyMat )
 {
    cubemap = BlueSkyCubemap;
    materialTag0 = "Skies";
+   isSky = true;
 };
 
 singleton CubemapData( GreySkyCubemap )
@@ -66,4 +68,5 @@ singleton Material( GreySkyMat )
 {
    cubemap = GreySkyCubemap;
    materialTag0 = "Skies";
+   isSky = true;
 };


### PR DESCRIPTION
Tacked on an additional isSky boolean that needs to be set in the material definition in order for it to trigger additional feature functionality.

On finding it, it flips on the MFT_SkyBox feature, which in turns appends the void DeferredSkyHLSL::processVert(  entries to a pre-existing definition for hlsl generation.
