### PR TITLE
Fixed spelling error on independentMrtBitDepth

### DIFF
--- a/Engine/source/gfx/D3D9/gfxD3D9CardProfiler.cpp
+++ b/Engine/source/gfx/D3D9/gfxD3D9CardProfiler.cpp
@@ -91,7 +91,7 @@ void GFXD3D9CardProfiler::setupCardCapabilities()
 
    setCapability( "lerpDetailBlend", canDoLERPDetailBlend );
    setCapability( "fourStageDetailBlend", canDoFourStageDetailBlend );
-   setCapability( "independentMrtBitDept", canDoIndependentMrtBitDepth);
+   setCapability( "independentMrtBitDepth", canDoIndependentMrtBitDepth);
 }
 
 bool GFXD3D9CardProfiler::_queryCardCap(const String &query, U32 &foundResult)

--- a/Engine/source/renderInstance/renderPrePassMgr.cpp
+++ b/Engine/source/renderInstance/renderPrePassMgr.cpp
@@ -170,9 +170,9 @@ bool RenderPrePassMgr::_updateTargets()
    }
 
    GFXFormat colorFormat = mTargetFormat;
-   bool independentMrtBitDept = GFX->getCardProfiler()->queryProfile("independentMrtBitDept", true);
+   bool independentMrtBitDepth = GFX->getCardProfiler()->queryProfile("independentMrtBitDepth", false);
    //If independent bit depth on a MRT is supported than just use 8bit channels for the albedo color.
-   if(independentMrtBitDept)
+   if(independentMrtBitDepth)
       colorFormat = GFXFormatR8G8B8A8;
 
    // andrewmac: Deferred Shading


### PR DESCRIPTION
- Fixed spelling error on independentMrtBitDepth
- Made default value false for "independentMrtBitDepth" when checking in renderPrePassMgr
