### PR TITLE
If not finding a specmap to derive a color alpha from, it defaults to fu...

### DIFF
--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -1764,7 +1764,13 @@ void ReflectCubeFeatHLSL::processPix(  Vector<ShaderComponent*> &componentList,
    else
    {
       if (fd.features[MFT_DeferredDiffuseMap])
+      {
         glossColor = (Var*)LangElement::find( "col1" );
+        if (!fd.features[MFT_DeferredSpecMap])
+        {
+            meta->addStatement( new GenOp( "   @.a = 1.0;\r\n", glossColor) );
+        }
+      }
       else
         glossColor = (Var*) LangElement::find( "diffuseColor" );
 


### PR DESCRIPTION
...ll reflectance as per stock torque functionality when not having a secondary material layer.
