### PR TITLE
reflection correction

### DIFF
--- a/Engine/source/scene/reflectionMatHook.cpp
+++ b/Engine/source/scene/reflectionMatHook.cpp
@@ -90,7 +90,7 @@ void ReflectionMaterialHook::_overrideFeatures(  ProcessedMaterial *mat,
    }
 
    // Forward shading on materials in reflections
-   fd.features.addFeature( MFT_ForwardShading );
+   //fd.features.addFeature( MFT_ForwardShading );
    fd.features.addFeature( MFT_Fog );
 }
 

--- a/Engine/source/scene/reflector.cpp
+++ b/Engine/source/scene/reflector.cpp
@@ -417,7 +417,7 @@ void CubeReflector::updateFace( const ReflectParams &params, U32 faceidx )
 
    reflectRenderState.getMaterialDelegate().bind( REFLECTMGR, &ReflectionManager::getReflectionMaterial );
    reflectRenderState.setDiffuseCameraTransform( params.query->cameraMatrix );
-   reflectRenderState.disableAdvancedLightingBins(true);
+   //reflectRenderState.disableAdvancedLightingBins(true);
 
    // render scene
    LIGHTMGR->registerGlobalLights( &reflectRenderState.getCullingFrustum(), false );
@@ -627,7 +627,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params )
       renderStateLeft.setSceneRenderField(0);
       renderStateLeft.getMaterialDelegate().bind( REFLECTMGR, &ReflectionManager::getReflectionMaterial );
       renderStateLeft.setDiffuseCameraTransform( params.query->cameraMatrix );
-      renderStateLeft.disableAdvancedLightingBins(true);
+      //renderStateLeft.disableAdvancedLightingBins(true);
 
       gClientSceneGraph->renderSceneNoLights( &renderStateLeft, objTypeFlag );
 
@@ -654,7 +654,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params )
       renderStateRight.setSceneRenderField(1);
       renderStateRight.getMaterialDelegate().bind( REFLECTMGR, &ReflectionManager::getReflectionMaterial );
       renderStateRight.setDiffuseCameraTransform( params.query->cameraMatrix );
-      renderStateRight.disableAdvancedLightingBins(true);
+      //renderStateRight.disableAdvancedLightingBins(true);
 
       gClientSceneGraph->renderSceneNoLights( &renderStateRight, objTypeFlag );
 
@@ -674,7 +674,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params )
 
       reflectRenderState.getMaterialDelegate().bind( REFLECTMGR, &ReflectionManager::getReflectionMaterial );
       reflectRenderState.setDiffuseCameraTransform( params.query->cameraMatrix );
-      reflectRenderState.disableAdvancedLightingBins(true);
+      //reflectRenderState.disableAdvancedLightingBins(true);
 
       gClientSceneGraph->renderSceneNoLights( &reflectRenderState, objTypeFlag );
    }

--- a/My Projects/testDS/game/core/scripts/client/lighting/advanced/deferredShading.cs
+++ b/My Projects/testDS/game/core/scripts/client/lighting/advanced/deferredShading.cs
@@ -43,6 +43,7 @@ singleton PostEffect( AL_DeferredShading )
    texture[1] = "#lightinfo";
    target = "$backBuffer";
    renderPriority = 10000;
+   allowReflectPass = true;
 };
 
 // Debug Shaders.


### PR DESCRIPTION
reflectionmathook.cpp: shut off the reflection mateiral being forced into forward shading mode

reflector.cpp: kills off disabling the advanced lighting bins when rendering reflections
deferredShading.cs: sets the result shader to allow rendering during reflection passes
